### PR TITLE
fix: don't release healthchecker during etcd sync due to compaction

### DIFF
--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -610,7 +610,7 @@ local function sync_data(self)
 
         if self.values then
             for i, val in ipairs(self.values) do
-                config_util.fire_all_clean_handlers(val)
+                config_util.fire_all_clean_handlers(val, self.compacted)
             end
 
             self.values = nil
@@ -629,6 +629,7 @@ local function sync_data(self)
     if not dir_res then
         if err == "compacted" then
             self.need_reload = true
+            self.compacted = true
             log.warn("waitdir [", self.key, "] err: ", err,
                      ", will read the configuration again via readdir")
             return false

--- a/apisix/core/config_util.lua
+++ b/apisix/core/config_util.lua
@@ -101,7 +101,7 @@ end
 
 
 -- fire all clean handlers added by add_clean_handler.
-function _M.fire_all_clean_handlers(item)
+function _M.fire_all_clean_handlers(item, is_compacted)
     -- When the key is deleted, the item will be set to false.
     if not item then
         return
@@ -111,7 +111,7 @@ function _M.fire_all_clean_handlers(item)
     end
 
     for _, clean_handler in ipairs(item.clean_handlers) do
-        clean_handler.f(item)
+        clean_handler.f(item, is_compacted)
     end
 
     item.clean_handlers = {}

--- a/apisix/upstream.lua
+++ b/apisix/upstream.lua
@@ -81,7 +81,11 @@ end
 _M.set = set_directly
 
 
-local function release_checker(healthcheck_parent)
+local function release_checker(healthcheck_parent, is_compacted)
+    if is_compacted then
+        core.log.info("need not release checker if reload is due to etcd compaction")
+        return
+    end
     local checker = healthcheck_parent.checker
     core.log.info("try to release checker: ", tostring(checker))
     checker:delayed_clear(3)


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
