### PR TITLE
fix(opa): clear unset send_headers_upstream entries to prevent header spoofing

### DIFF
--- a/apisix/plugins/opa.lua
+++ b/apisix/plugins/opa.lua
@@ -137,12 +137,14 @@ function _M.access(conf, ctx)
         end
 
         return status_code, reason
-    else if result.headers and conf.send_headers_upstream then
+    else if conf.send_headers_upstream then
+        local headers = result.headers or {}
+        -- set headers from the OPA response, clearing any client-supplied
+        -- values for configured headers not present in the OPA response
         for _, name in ipairs(conf.send_headers_upstream) do
-            local value = result.headers[name]
-            if value then
-                core.request.set_header(ctx, name, value)
-            end
+            local value = headers[name]
+            -- if value is nil, the client header's value will be removed if it exists
+            core.request.set_header(ctx, name, value)
         end
         end
     end

--- a/t/plugin/opa3.t
+++ b/t/plugin/opa3.t
@@ -1,0 +1,108 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: setup mock OPA route and protected route
+--- config
+    location /t {
+        content_by_lua_block {
+            local data = {
+                {
+                    url = "/apisix/admin/upstreams/u1",
+                    data = [[{
+                        "nodes": {
+                            "127.0.0.1:1984": 1
+                        },
+                        "type": "roundrobin"
+                    }]],
+                },
+                {
+                    -- mock OPA: returns allow=true with NO headers field
+                    url = "/apisix/admin/routes/opa_mock",
+                    data = {
+                        plugins = {
+                            ["serverless-pre-function"] = {
+                                phase = "rewrite",
+                                functions =  {
+                                    [[return function(conf, ctx)
+                                        local core = require("apisix.core")
+                                        core.response.exit(200, {result = {allow = true}})
+                                    end]]
+                                }
+                            }
+                        },
+                        uri = "/v1/data/example"
+                    },
+                },
+                {
+                    url = "/apisix/admin/routes/1",
+                    data = [[{
+                        "plugins": {
+                            "opa": {
+                                "host": "http://127.0.0.1:1984",
+                                "policy": "example",
+                                "send_headers_upstream": ["X-Foo"]
+                            },
+                            "serverless-post-function": {
+                                "phase": "access",
+                                "functions": [
+                                    "return function(conf, ctx) local core = require(\"apisix.core\"); core.response.exit(200, core.request.headers(ctx)); end"
+                                ]
+                            }
+                        },
+                        "upstream_id": "u1",
+                        "uri": "/echo"
+                    }]],
+                }
+            }
+
+            local t = require("lib.test_admin").test
+
+            for _, data in ipairs(data) do
+                local code, body = t(data.url, ngx.HTTP_PUT, data.data)
+                ngx.say(body)
+            end
+        }
+    }
+--- response_body eval
+"passed\n" x 3
+
+
+
+=== TEST 2: client-supplied send_headers_upstream entry is cleared when OPA omits it
+--- request
+GET /echo
+--- more_headers
+X-Foo: spoofed
+--- response_body_unlike eval
+qr/spoofed/


### PR DESCRIPTION
## Summary

When the `opa` plugin is configured with `send_headers_upstream` and the OPA
server returns `allow = true` without including one of the configured headers
in its response (or without a `headers` field at all), the plugin previously
left any client-supplied value for that header in place on the upstream
request. If the upstream trusts that header as identity or authorization
context, this is a header-spoofing primitive.

This is the same bug shape as the forward-auth fix for CVE-2026-31908.

## Fix

In `apisix/plugins/opa.lua`, when the OPA decision is `allow = true` and
`send_headers_upstream` is configured, iterate over every configured header
name and call `core.request.set_header(ctx, name, value)` with the OPA
response value (which may be `nil`). When `value` is `nil`, the client
header is removed instead of being passed through. The condition no longer
short-circuits on a missing `result.headers` field.

## Test

`t/plugin/opa3.t` adds a regression test that mocks an OPA server via a
local APISIX route returning `{"result": {"allow": true}}` (no headers
field), configures the protected route with `send_headers_upstream: ["X-Foo"]`,
sends `X-Foo: spoofed` from the client, and asserts the upstream does not
see `spoofed`. Follows the same pattern as `t/plugin/forward-auth3.t`.

## Notes

- Minimal, security-only diff. No refactors.
- `make lint` (luacheck) passes on the modified file.
- Full `prove` suite not run locally (needs live APISIX runtime); test
  syntactically validated.
- Same bug shape as the forward-auth fix for CVE-2026-31908; no new CVE
  ID assigned in this PR.

## Test plan

- [ ] Bring up etcd and run `prove -I. -r t/plugin/opa3.t`.
- [ ] Confirm the existing `t/plugin/opa.t` send_headers_upstream test
      (TEST 12/13) still passes against a real OPA server.